### PR TITLE
Refactor/input parsing

### DIFF
--- a/src/commands/__init__.py
+++ b/src/commands/__init__.py
@@ -7,19 +7,11 @@ from .mkdir import handle_mkdir
 from .cd import handle_cd
 
 command_map = {
-    "cd": {"handler": handle_cd, "args": ["folder_name"], "usage": "<folder_name>"},
-    "ls": {"handler": handle_ls, "args": [], "usage": ""},
-    "clear": {"handler": handle_clear, "args": [], "usage": ""},
-    "mkdir": {
-        "handler": handle_mkdir,
-        "args": ["folder_name"],
-        "usage": "<folder_name>",
-    },
-    "rm": {"handler": handle_rm, "args": ["item_name"], "usage": "<item_name>"},
-    "download": {
-        "handler": handle_download,
-        "args": ["item_name"],
-        "usage": "<item_name>",
-    },
-    "upload": {"handler": handle_upload, "args": ["file_path"], "usage": "<file_path>"},
+    "cd": {"handler": handle_cd},
+    "ls": {"handler": handle_ls},
+    "clear": {"handler": handle_clear},
+    "mkdir": {"handler": handle_mkdir},
+    "rm": {"handler": handle_rm},
+    "download": {"handler": handle_download},
+    "upload": {"handler": handle_upload},
 }

--- a/src/commands/cd.py
+++ b/src/commands/cd.py
@@ -1,9 +1,17 @@
-def handle_cd(session, folder_name):
+import argparse
+
+
+def handle_cd(session, *args):
+    parser = argparse.ArgumentParser(prog="mkdir")
+    parser.add_argument("directory_name")
+    parsed = parser.parse_args(args)
+
+    directory_name = parsed.directory_name
     for item in session.cwd.children:
         if (
-            item.name == folder_name
+            item.name == directory_name
             and item.mime_type == "application/vnd.google-apps.folder"
         ):
             session.cwd = item
             return
-    raise FileNotFoundError(folder_name)
+    raise FileNotFoundError(directory_name)

--- a/src/commands/download.py
+++ b/src/commands/download.py
@@ -1,7 +1,13 @@
+import argparse
 from drive_tree import tree_utils
 
 
-def handle_download(session, item_name):
+def handle_download(session, *args):
+    parser = argparse.ArgumentParser(prog="download")
+    parser.add_argument("item_name")
+    parsed = parser.parse_args(args)
+
+    item_name = parsed.item_name
     client = session.client
 
     item = tree_utils.get_item_by_name(session, item_name)

--- a/src/commands/ls.py
+++ b/src/commands/ls.py
@@ -1,3 +1,9 @@
-def handle_ls(session):
+import argparse
+
+
+def handle_ls(session, *args):
+    parser = argparse.ArgumentParser(prog="ls")
+    parsed = parser.parse_args(args)
+
     for item in session.cwd.children:
         print(item.name)

--- a/src/commands/mkdir.py
+++ b/src/commands/mkdir.py
@@ -1,11 +1,17 @@
+import argparse
 from drive_tree.drive_node import DriveNode
 
 
-def handle_mkdir(session, folder_name):
+def handle_mkdir(session, *args):
+    parser = argparse.ArgumentParser(prog="mkdir")
+    parser.add_argument("directory_name")
+    parsed = parser.parse_args(args)
+
+    directory_name = parsed.directory_name
     client = session.client
     curr_dir = session.cwd
 
-    created_folder = client.create_dir(folder_name, curr_dir.id)
+    created_folder = client.create_dir(directory_name, curr_dir.id)
     new_dir = DriveNode(
         created_folder.get("id"),
         created_folder.get("name"),

--- a/src/commands/rm.py
+++ b/src/commands/rm.py
@@ -1,7 +1,13 @@
+import argparse
 from drive_tree import tree_utils
 
 
-def handle_rm(session, item_name):
+def handle_rm(session, *args):
+    parser = argparse.ArgumentParser(prog="rm")
+    parser.add_argument("item_name")
+    parsed = parser.parse_args(args)
+
+    item_name = parsed.item_name
     client = session.client
     curr_dir = session.cwd
 

--- a/src/commands/upload.py
+++ b/src/commands/upload.py
@@ -1,8 +1,14 @@
 import os
+import argparse
 from drive_tree.drive_node import DriveNode
 
 
-def handle_upload(session, file_path):
+def handle_upload(session, *args):
+    parser = argparse.ArgumentParser(prog="upload")
+    parser.add_argument("item_name")
+    parsed = parser.parse_args(args)
+
+    file_path = parsed.item_name
     client = session.client
     curr_dir = session.cwd
 

--- a/src/session.py
+++ b/src/session.py
@@ -39,17 +39,10 @@ class Session:
                         print(f"Did you mean '{best_match}'?")
                     continue
 
-                expected_args = cmd_info.get("args", [])
-                if len(args) != len(expected_args):
-                    usage = cmd_info.get("usage")
-                    print(f"Usage: {cmd} {usage}")
-                    continue
-
                 try:
                     handler = cmd_info.get("handler")
-                    kwargs = dict(zip(expected_args, args))
                     if handler:
-                        handler(self, **kwargs)
+                        handler(self, *args)
                 except FileNotFoundError as e:
                     print(f"[Not Found] Command '{cmd}': No such item: {e}")
                 except HttpError as e:
@@ -57,6 +50,8 @@ class Session:
                     print(
                         f"[API Error] Command '{cmd}': Server responded with an error: {error_code} {HTTPStatus(error_code).phrase}"
                     )
+                except SystemExit:
+                    continue
                 except Exception as e:
                     print(f"[Unexpected Error] Command '{cmd}': {e}")
 


### PR DESCRIPTION
use argparse to handle input parsing (allows for generated usage message, easier argument/flag expandability in future)

- handle input parsing in each command instead of generically in the cli loop
- modify handler to use *args instead of **kwargs 
- remove usage and args from command_map
