### PR TITLE
feat: add parser deault argument to cd handler

### DIFF
--- a/src/commands/cd.py
+++ b/src/commands/cd.py
@@ -3,7 +3,7 @@ import argparse
 
 def handle_cd(session, *args):
     parser = argparse.ArgumentParser(prog="cd")
-    parser.add_argument("path")
+    parser.add_argument("path", nargs="?", default="/")
     parsed = parser.parse_args(args)
 
     session.drive_tree.cd(parsed.path)


### PR DESCRIPTION
- entering cd with no arguments goes to root dir