### PR TITLE
Refactor/improve vfs reuseability

### DIFF
--- a/src/session.py
+++ b/src/session.py
@@ -9,7 +9,8 @@ from auth.google_auth import get_auth_service
 from autocomplete import create_completer, setup_autocomplete
 from commands import command_map
 from services.drive_client import DriveClient
-from vfs.drive_vfs import DriveVFS
+from vfs.drive_node import DriveNode
+from vfs.vfs import VFS
 
 
 class Session:
@@ -18,7 +19,7 @@ class Session:
     def __init__(self):
         try:
             self.client = DriveClient(get_auth_service)
-            self.vfs = DriveVFS(self.client)
+            self.vfs = VFS(self.client, DriveNode)
         except GoogleAuthError:
             raise GoogleAuthError("Drive authentication failed.")
         except Exception:

--- a/src/vfs/drive_node.py
+++ b/src/vfs/drive_node.py
@@ -1,32 +1,5 @@
-class DriveNode:
-    def __init__(self, id, name, mime_type):
-        self.id = id
-        self.name = name
-        self.mime_type = mime_type
-        self.parent = None
-        self.children = []
+from .node import Node
 
-    def is_folder(self):
-        return self.mime_type == "application/vnd.google-apps.folder"
 
-    def add_child(self, child_node):
-        self.children.append(child_node)
-        child_node.parent = self
-
-    def remove_child(self, child_node):
-        if child_node in self.children:
-            self.children.remove(child_node)
-            child_node.parent = None
-
-    def detach(self):
-        if self.parent:
-            self.parent.remove_child(self)
-            self.parent = None
-
-    def get_path(self):
-        if self.parent is None:
-            return "/"
-        if self.parent.get_path() == "/":
-            return f"/{self.name}"
-
-        return f"{self.parent.get_path()}/{self.name}"
+class DriveNode(Node):
+    folder_mimetype = "application/vnd.google-apps.folder"

--- a/src/vfs/node.py
+++ b/src/vfs/node.py
@@ -1,0 +1,34 @@
+class Node:
+    folder_mimetype = None
+
+    def __init__(self, id, name, mime_type):
+        self.id = id
+        self.name = name
+        self.mime_type = mime_type
+        self.parent = None
+        self.children = []
+
+    def is_folder(self):
+        return self.mime_type == self.folder_mimetype
+
+    def add_child(self, child_node):
+        self.children.append(child_node)
+        child_node.parent = self
+
+    def remove_child(self, child_node):
+        if child_node in self.children:
+            self.children.remove(child_node)
+            child_node.parent = None
+
+    def detach(self):
+        if self.parent:
+            self.parent.remove_child(self)
+            self.parent = None
+
+    def get_path(self):
+        if self.parent is None:
+            return "/"
+        if self.parent.get_path() == "/":
+            return f"/{self.name}"
+
+        return f"{self.parent.get_path()}/{self.name}"

--- a/src/vfs/vfs.py
+++ b/src/vfs/vfs.py
@@ -1,13 +1,13 @@
 class VFS:
     def __init__(self, client, node_cls):
-        self.client = client
+        self._client = client
         self._node_cls = node_cls
         self.root = self.__build()
         self.cwd = self.root
 
     def __build(self):
-        all_files = self.client.list_all_files()
-        root_id = self.client.get_root_id()
+        all_files = self._client.list_all_files()
+        root_id = self._client.get_root_id()
 
         # Create dictionary of nodes using files
         drive_nodes = {
@@ -43,7 +43,7 @@ class VFS:
 
         parent_node = self._resolve_node_by_path(parent_path)
 
-        file_info = self.client.create_dir(dir_name, parent_node.id)
+        file_info = self._client.create_dir(dir_name, parent_node.id)
         file_node = self._node_cls(
             file_info.get("id"),
             file_info.get("name"),
@@ -53,15 +53,15 @@ class VFS:
 
     def rm(self, path):
         file_node = self._resolve_node_by_path(path)
-        self.client.delete_file(file_node.id)
+        self._client.delete_file(file_node.id)
         file_node.detach()
 
     def download(self, path):
         file_node = self._resolve_node_by_path(path)
-        self.client.download_file(file_node.id, file_node.name, file_node.mime_type)
+        self._client.download_file(file_node.id, file_node.name, file_node.mime_type)
 
     def upload(self, local_path):
-        file_info = self.client.upload_file(local_path, self.cwd.id)
+        file_info = self._client.upload_file(local_path, self.cwd.id)
         file_node = self._node_cls(
             file_info.get("id"),
             file_info.get("name"),


### PR DESCRIPTION
refactor vfs and nodes (remove drive-specific variables/methods/content)
- Node is_folder() method checks folder mimetype using value set by inheriting subclass
- VFS uses node_cls that is passed as arg to constructor which modifying vfs structure instead of always using DriveNode
- DriveNode inherits from Node class